### PR TITLE
working with docker compose

### DIFF
--- a/.github/workflows/test_the_docs.yml
+++ b/.github/workflows/test_the_docs.yml
@@ -38,6 +38,9 @@ jobs:
       # wait is 60 seconds.
       - name: Start StarRocks
         run: docker compose up --detach --wait --wait-timeout 60
+        env:
+          AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
+          AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
 
       - name: Test
         run: ginkgo

--- a/.github/workflows/test_the_docs.yml
+++ b/.github/workflows/test_the_docs.yml
@@ -14,36 +14,19 @@ jobs:
 
     steps:
       # Checkout the repo as this CI needs:
-      # - the compose file for StarRocks
-      # - the Ginkgo/Gomega test system
+      # - the compose file for StarRocks and Ginkgo/Gomega
       - uses: actions/checkout@v3
 
-      - name: Set up Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Install ginkgo
-        run: |
-          version=$(cat go.mod| grep "ginkgo/v2" | awk '{print $2}')
-          go install -v github.com/onsi/ginkgo/v2/ginkgo@$version
-
-      - name: Build
-        run: go build -v ./...
-
-      # This compose step will deploy StarRocks
+      # This compose step will deploy StarRocks and
+      # the test harness (Golang/Ginkgo/Gomega)
       # in Docker using the compose file in this repo
-      # docker compose will return when both services
+      # docker compose will return when all services
       # are healthy. The max time docker compose will
       # wait is 60 seconds.
+      # The secrets for Amazon S3 are used to retrieve
+      # datasets.
       - name: Start StarRocks
         run: docker compose up --detach --wait --wait-timeout 60
-        env:
-          AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
-
-      - name: Test
-        run: ginkgo
         env:
           AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}

--- a/ci/SHELL/NYPD_stream_load
+++ b/ci/SHELL/NYPD_stream_load
@@ -1,6 +1,7 @@
 #!/bin/ash
 cd /tmp/
-curl --location-trusted -u root:""          \
+curl --silent --no-buffer                   \
+    --location-trusted -u root:""           \
     -T ./NYPD_Crash_Data.csv                \
     -H "label:crashdata-0"                  \
     -H "column_separator:,"                 \
@@ -8,4 +9,4 @@ curl --location-trusted -u root:""          \
     -H "enclose:\""                         \
     -H "max_filter_ratio:1"                 \
     -H "columns:tmp_CRASH_DATE, tmp_CRASH_TIME, CRASH_DATE=str_to_date(concat_ws(' ', tmp_CRASH_DATE, tmp_CRASH_TIME), '%m/%d/%Y %H:%i'),BOROUGH,ZIP_CODE,LATITUDE,LONGITUDE,LOCATION,ON_STREET_NAME,CROSS_STREET_NAME,OFF_STREET_NAME,NUMBER_OF_PERSONS_INJURED,NUMBER_OF_PERSONS_KILLED,NUMBER_OF_PEDESTRIANS_INJURED,NUMBER_OF_PEDESTRIANS_KILLED,NUMBER_OF_CYCLIST_INJURED,NUMBER_OF_CYCLIST_KILLED,NUMBER_OF_MOTORIST_INJURED,NUMBER_OF_MOTORIST_KILLED,CONTRIBUTING_FACTOR_VEHICLE_1,CONTRIBUTING_FACTOR_VEHICLE_2,CONTRIBUTING_FACTOR_VEHICLE_3,CONTRIBUTING_FACTOR_VEHICLE_4,CONTRIBUTING_FACTOR_VEHICLE_5,COLLISION_ID,VEHICLE_TYPE_CODE_1,VEHICLE_TYPE_CODE_2,VEHICLE_TYPE_CODE_3,VEHICLE_TYPE_CODE_4,VEHICLE_TYPE_CODE_5" \
-    -XPUT http://127.0.0.1:8030/api/quickstart/crashdata/_stream_load
+    -XPUT http://fe:8030/api/quickstart/crashdata/_stream_load

--- a/ci/docs_test.go
+++ b/ci/docs_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Docs", func() {
 			User:   "root",
 			Passwd: "",
 			Net:    "tcp",
-			Addr:   "127.0.0.1:9030",
+			Addr:   "fe:9030",
 			AllowNativePasswords: true,
 		}
 

--- a/ci/ginkgo.Dockerfile
+++ b/ci/ginkgo.Dockerfile
@@ -4,13 +4,13 @@ USER 0
 WORKDIR /workspace
 
 
-COPY ci ci
+COPY . .
 
 # install curl
 RUN apk --no-cache add curl
 
 # Install Ginkgo CLI to run unit tests inside the container
-RUN cd ci && go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
 
-RUN cd ci && go mod download
+RUN go mod download
 

--- a/ci/quickstart_basic_test.go
+++ b/ci/quickstart_basic_test.go
@@ -25,7 +25,7 @@ var _ = Describe("QuickstartBasic", func() {
 			User:                 "root",
 			Passwd:               "",
 			Net:                  "tcp",
-			Addr:                 "127.0.0.1:9030",
+			Addr:                 "fe:9030",
 			AllowNativePasswords: true,
 		}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,24 @@
 version: "3.9"
 services:
 
+  test-harness:
+    image: ginkgo
+    hostname: ginkgo
+    container_name: ginkgo
+    environment:
+      - AWS_S3_ACCESS_KEY=${AWS_S3_ACCESS_KEY}
+      - AWS_S3_SECRET_KEY=${AWS_S3_SECRET_KEY}
+    user: root
+    build:
+      context: ci
+      dockerfile: ginkgo.Dockerfile
+    depends_on:
+      starrocks-be:
+        condition: service_healthy
+        restart: true
+    command:
+      ginkgo -vv
+
   starrocks-fe:
     image: starrocks/fe-ubuntu:3.2-latest
     hostname: fe
@@ -26,13 +44,15 @@ services:
       - /bin/bash
       - -c
       - |
-        sleep 30s; mysql --connect-timeout 2 -h fe -P 9030 -u root -e "alter system add backend \"be:9050\";"
+        sleep 10s; mysql --connect-timeout 2 -h fe -P 9030 -u root -e "alter system add backend \"be:9050\";"
         /opt/starrocks/be/bin/start_be.sh
     hostname: be
     container_name: be
     user: root
     depends_on:
-      - starrocks-fe
+      starrocks-fe:
+        condition: service_healthy
+        restart: true
     ports:
       - 8040:8040
     healthcheck:


### PR DESCRIPTION
- Move Ginkgo/Gomega from the ci workflow into the docker compose (which is run from the ci workflow). This allows the Ginkgo tests to access the containers directly, which is necessary because when using STREAM LOAD to upload data the frontend node (FE) redirects to a backend node (BE) by name.
- Adds a Dockerfile to build the test service
- Adds a prerequisite to the BE service that the FE be healthy before starting
- Adds a prerequisite to the test-harness service that the BE be healthy before starting
