### PR TITLE
Background StarRocks, foreground Ginkgo

### DIFF
--- a/.github/workflows/test_the_docs.yml
+++ b/.github/workflows/test_the_docs.yml
@@ -17,7 +17,7 @@ jobs:
       # - the compose file for StarRocks and Ginkgo/Gomega
       - uses: actions/checkout@v3
 
-      # This compose step will deploy StarRocks and
+      # These two compose steps will deploy StarRocks and
       # the test harness (Golang/Ginkgo/Gomega)
       # in Docker using the compose file in this repo
       # docker compose will return when all services
@@ -26,7 +26,10 @@ jobs:
       # The secrets for Amazon S3 are used to retrieve
       # datasets.
       - name: Start StarRocks
-        run: docker compose up --detach --wait --wait-timeout 60
+        run: docker compose --profile starrocks up --detach --wait --wait-timeout 60
+
+      - name: Run Tests
         env:
           AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
+        run: docker compose run test-harness

--- a/README.md
+++ b/README.md
@@ -122,9 +122,17 @@ Code snippets are imported from the tests using [`docusaurus-theme-github-codebl
 ## Running the system
 
 1. Clone this repo
-1. Install Golang, Ginkgo, and Gomega
-1. `docker compose up --detach --wait --wait-timeout 60`
-1. `ginkgo -vv`
+2. Start StarRocks
+
+```bash
+docker compose --profile starrocks up --detach --wait --wait-timeout 60
+```
+
+3. Run the tests
+
+```bash
+docker compose run test-harness
+```
 
 ## Add a new test
 
@@ -133,15 +141,3 @@ To test the basic [quickstart](https://docs.starrocks.io/docs/quick_start/shared
 ```bash
 ginkgo generate quickstart_basic
 ```
-
-## TEMP
-
-Temporary until I add the Ginkgo container to the compose file.
-
-Dockerfile for ginkgo is in root dir of repo
-
-docker build .
-
-docker run  -ti \
---network host \
-ca538899436c0b584ed26eada78e72008360b67c19abe ash

--- a/ci/quickstart_basic_test.go
+++ b/ci/quickstart_basic_test.go
@@ -64,7 +64,7 @@ var _ = Describe("QuickstartBasic", func() {
 
 		It("should be able to run SQL commands", func() {
 			By("choosing a database")
-			_, err := db.Exec(`USE xquickstart`)
+			_, err := db.Exec(`USE quickstart`)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/ci/quickstart_basic_test.go
+++ b/ci/quickstart_basic_test.go
@@ -64,7 +64,7 @@ var _ = Describe("QuickstartBasic", func() {
 
 		It("should be able to run SQL commands", func() {
 			By("choosing a database")
-			_, err := db.Exec(`USE quickstart`)
+			_, err := db.Exec(`USE xquickstart`)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,11 @@
 version: "3.9"
 services:
 
-  test-harness:
-    image: ginkgo
-    hostname: ginkgo
-    container_name: ginkgo
-    environment:
-      - AWS_S3_ACCESS_KEY=${AWS_S3_ACCESS_KEY}
-      - AWS_S3_SECRET_KEY=${AWS_S3_SECRET_KEY}
-    user: root
-    build:
-      context: ci
-      dockerfile: ginkgo.Dockerfile
-    depends_on:
-      starrocks-be:
-        condition: service_healthy
-        restart: true
-    command:
-      ginkgo -vv
-
   starrocks-fe:
     image: starrocks/fe-ubuntu:3.2-latest
     hostname: fe
     container_name: fe
+    profiles: [starrocks]
     user: root
 
     command:
@@ -48,6 +31,7 @@ services:
         /opt/starrocks/be/bin/start_be.sh
     hostname: be
     container_name: be
+    profiles: [starrocks]
     user: root
     depends_on:
       starrocks-fe:
@@ -60,3 +44,23 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  test-harness:
+    image: ginkgo
+    hostname: ginkgo
+    container_name: ginkgo
+    profiles: [test-harness]
+    environment:
+      - AWS_S3_ACCESS_KEY=${AWS_S3_ACCESS_KEY}
+      - AWS_S3_SECRET_KEY=${AWS_S3_SECRET_KEY}
+    user: root
+    build:
+      context: ci
+      dockerfile: ginkgo.Dockerfile
+        #depends_on:
+        #starrocks-be:
+        #condition: service_healthy
+        #restart: true
+    command:
+      ginkgo -vv
+


### PR DESCRIPTION
By putting StarRocks in one Docker compose profile and Ginkgo in another we can run StarRocks in the background and then run the tests in the foreground.