### PR TITLE
Separate runs by file

### DIFF
--- a/.github/workflows/test_the_docs.yml
+++ b/.github/workflows/test_the_docs.yml
@@ -11,6 +11,8 @@ on:
     branches: [ main ]
     paths:
       - 'ci/**/*'
+      - '.github/workflows/test_the_docs.yml'
+      - 'docker-compose.yml'
 
 jobs:
   build:

--- a/.github/workflows/test_the_docs.yml
+++ b/.github/workflows/test_the_docs.yml
@@ -29,13 +29,21 @@ jobs:
       # docker compose will return when all services
       # are healthy. The max time docker compose will
       # wait is 60 seconds.
-      # The secrets for Amazon S3 are used to retrieve
-      # datasets.
       - name: Start StarRocks
         run: docker compose --profile starrocks up --detach --wait --wait-timeout 60
 
-      - name: Run Tests
+      - name: Test; FILES() table function
+      # The secrets for Amazon S3 are used to retrieve
+      # datasets.
         env:
           AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
-        run: docker compose run test-harness
+        run: docker compose run test-harness ginkgo -v \
+             --focus-file=./docs_test.go
+
+      - name: Test; Basic Quick Start
+        env:
+          AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
+          AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
+        run: docker compose run test-harness ginkgo -v \
+             --focus-file=./quickstart_basic_test.go

--- a/.github/workflows/test_the_docs.yml
+++ b/.github/workflows/test_the_docs.yml
@@ -31,6 +31,9 @@ jobs:
       # docker compose will return when all services
       # are healthy. The max time docker compose will
       # wait is 60 seconds.
+      - name: Build Ginkgo container
+        run: docker compose build test-harness
+
       - name: Start StarRocks
         run: docker compose --profile starrocks up --detach --wait --wait-timeout 60
 
@@ -44,6 +47,7 @@ jobs:
              --focus-file=./docs_test.go
 
       - name: Test; Basic Quick Start
+        if: always()
         env:
           AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}

--- a/.github/workflows/test_the_docs.yml
+++ b/.github/workflows/test_the_docs.yml
@@ -43,13 +43,11 @@ jobs:
         env:
           AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
-        run: docker compose run test-harness ginkgo -v \
-             --focus-file=./docs_test.go
+        run: docker compose run test-harness ginkgo -v --focus-file=./docs_test.go
 
       - name: Test; Basic Quick Start
         if: always()
         env:
           AWS_S3_ACCESS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_S3_SECRET_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
-        run: docker compose run test-harness ginkgo -v \
-             --focus-file=./quickstart_basic_test.go
+        run: docker compose run test-harness ginkgo -v --focus-file=./quickstart_basic_test.go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,3 @@ services:
     build:
       context: ci
       dockerfile: ginkgo.Dockerfile
-    command:
-      ginkgo -vv
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - /bin/bash
       - -c
       - |
-        sleep 10s; mysql --connect-timeout 2 -h fe -P 9030 -u root -e "alter system add backend \"be:9050\";"
+        sleep 3s; mysql --connect-timeout 2 -h fe -P 9030 -u root -e "alter system add backend \"be:9050\";"
         /opt/starrocks/be/bin/start_be.sh
     hostname: be
     container_name: be


### PR DESCRIPTION
Move the command for the test harness out of docker compose file and into the workflow file so I can  separate the output by document being tested