### PR TITLE
fixed compose

### DIFF
--- a/.github/workflows/load_from_minio.yml
+++ b/.github/workflows/load_from_minio.yml
@@ -53,12 +53,10 @@ jobs:
           working-directory: demo/documentation-samples/utility
   
         - name: Download dataset
-          if: always()
           run: curl -O https://starrocks-examples.s3.amazonaws.com/user_behavior_ten_million_rows.parquet
           working-directory: demo/documentation-samples/utility
 
         - name: Move dataset into MinIO bucket
-          if: always()
           run: |
             docker compose exec minio mc alias set myminio http://minio:9000 miniouser miniopassword
             docker compose cp user_behavior_ten_million_rows.parquet minio:/tmp/
@@ -68,7 +66,6 @@ jobs:
         # The ginkgo command uses `--focus-file` to run only the one test
         # file.
         - name: Test; Hudi SQL test
-          if: always()
           env:
             SR_FE_HOST: 'localhost'
           run: |


### PR DESCRIPTION
minio mc container is now long lived, so removed the workaround for the exit code.